### PR TITLE
Update README.md with fix in local command

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Add the following configuration to your MCP client settings:
 {
     "mcpServers": {
         "LangSmith API MCP Server": {
-            "command": "/path/to/uvx",
+            "command": "/path/to/uv",
             "args": [
                 "--directory",
                 "/path/to/langsmith-mcp-server/langsmith_mcp_server",


### PR DESCRIPTION
The wrong command (probably a typo) in the docs prevents the usage of the mcp server locally