### PR TITLE
fix: correct installation command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Once you have the LangSmith MCP Server, you can integrate it with various MCP-co
 
 1. Install the package:
    ```bash
-   uv run pip install --upgrade langsmith-mcp-server
+   uv pip install --upgrade langsmith-mcp-server
    ```
 
 2. Add to your client MCP config:


### PR DESCRIPTION
Pretty sure this is a typo? Couldn't get it to work otherwise. 

`uv run pip3 install --upgrade langsmith-mcp-server
`

This causes an externally-managed-environment error in the terminal