### PR TITLE
feat: Add comprehensive testing infrastructure

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,201 @@
+"""Shared test fixtures for langsmith-mcp-server tests."""
+
+import pytest
+from unittest.mock import Mock, MagicMock
+from typing import Any, Dict, List, Optional
+from datetime import datetime
+from uuid import uuid4
+
+
+@pytest.fixture
+def mock_langsmith_client():
+    """Create a mock LangSmith client for testing."""
+    client = Mock()
+    
+    # Configure default return values
+    client.list_prompts = Mock(return_value=[])
+    client.list_datasets = Mock(return_value=[])
+    client.list_examples = Mock(return_value=[])
+    client.list_runs = Mock(return_value=[])
+    client.list_projects = Mock(return_value=[])
+    client.read_dataset = Mock(return_value=None)
+    client.read_example = Mock(return_value=None)
+    client.get_run_stats = Mock(return_value={})
+    
+    return client
+
+
+@pytest.fixture
+def mock_prompt():
+    """Create a mock prompt object."""
+    prompt = Mock()
+    prompt.name = "test-prompt"
+    prompt.id = str(uuid4())
+    prompt.is_public = False
+    prompt.description = "Test prompt description"
+    prompt.created_at = datetime.now()
+    prompt.updated_at = datetime.now()
+    prompt.prompt = {
+        "messages": [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "{input}"}
+        ]
+    }
+    return prompt
+
+
+@pytest.fixture
+def mock_dataset():
+    """Create a mock dataset object."""
+    dataset = Mock()
+    dataset.id = uuid4()
+    dataset.name = "test-dataset"
+    dataset.description = "Test dataset description"
+    dataset.data_type = "kv"
+    dataset.example_count = 10
+    dataset.session_count = 5
+    dataset.created_at = datetime.now()
+    dataset.modified_at = datetime.now()
+    dataset.last_session_start_time = None
+    dataset.inputs_schema_definition = None
+    dataset.outputs_schema_definition = None
+    return dataset
+
+
+@pytest.fixture
+def mock_example():
+    """Create a mock example object."""
+    example = Mock()
+    example.id = uuid4()
+    example.dataset_id = uuid4()
+    example.inputs = {"question": "What is the capital of France?"}
+    example.outputs = {"answer": "Paris"}
+    example.metadata = {"source": "test"}
+    example.created_at = datetime.now()
+    example.modified_at = datetime.now()
+    example.runs = []
+    example.source_run_id = None
+    example.attachments = None
+    return example
+
+
+@pytest.fixture
+def mock_run():
+    """Create a mock run object."""
+    run = Mock()
+    run.id = uuid4()
+    run.name = "test-run"
+    run.run_type = "chain"
+    run.start_time = datetime.now()
+    run.end_time = datetime.now()
+    run.inputs = {"input": "test input"}
+    run.outputs = {"output": "test output"}
+    run.error = None
+    run.total_tokens = 100
+    run.total_cost = 0.001
+    run.feedback_stats = {}
+    run.app_path = "/test"
+    run.thread_id = str(uuid4())
+    run.trace_id = str(uuid4())
+    run.metadata = {}
+    run.tags = []
+    
+    # Add dict method for serialization
+    def dict_method():
+        return {
+            "id": run.id,
+            "name": run.name,
+            "run_type": run.run_type,
+            "start_time": run.start_time,
+            "end_time": run.end_time,
+            "inputs": run.inputs,
+            "outputs": run.outputs,
+            "error": run.error,
+            "total_tokens": run.total_tokens,
+            "total_cost": run.total_cost,
+            "feedback_stats": run.feedback_stats,
+            "app_path": run.app_path,
+            "thread_id": run.thread_id,
+            "trace_id": run.trace_id,
+            "metadata": run.metadata,
+            "tags": run.tags,
+        }
+    
+    run.dict = dict_method
+    return run
+
+
+@pytest.fixture
+def mock_project():
+    """Create a mock project object."""
+    project = Mock()
+    project.id = uuid4()
+    project.name = "test-project"
+    project.description = "Test project description"
+    project.created_at = datetime.now()
+    project.metadata = {}
+    
+    # Add dict method for serialization
+    def dict_method():
+        return {
+            "id": project.id,
+            "name": project.name,
+            "description": project.description,
+            "created_at": project.created_at,
+            "metadata": project.metadata,
+        }
+    
+    project.dict = dict_method
+    return project
+
+
+@pytest.fixture
+def mock_context():
+    """Create a mock FastMCP context."""
+    context = Mock()
+    
+    # Mock state storage
+    context._state = {}
+    
+    def get_state(key: str, default: Any = None) -> Any:
+        return context._state.get(key, default)
+    
+    def set_state(key: str, value: Any) -> None:
+        context._state[key] = value
+    
+    context.get_state = get_state
+    context.set_state = set_state
+    context.get_http_request = Mock(return_value=None)
+    
+    return context
+
+
+@pytest.fixture
+def sample_api_key():
+    """Provide a sample API key for testing."""
+    return "lsv2_pt_test_api_key_12345"
+
+
+@pytest.fixture
+def sample_workspace_id():
+    """Provide a sample workspace ID for testing."""
+    return str(uuid4())
+
+
+@pytest.fixture
+def mock_http_request(sample_api_key, sample_workspace_id):
+    """Create a mock HTTP request with headers."""
+    request = Mock()
+    request.headers = {
+        "LANGSMITH-API-KEY": sample_api_key,
+        "LANGSMITH-WORKSPACE-ID": sample_workspace_id,
+        "LANGSMITH-ENDPOINT": "https://api.smith.langchain.com",
+    }
+    request.state = Mock()
+    request.state.api_key = sample_api_key
+    request.state.workspace_id = sample_workspace_id
+    request.state.endpoint = "https://api.smith.langchain.com"
+    request.url = Mock()
+    request.url.path = "/mcp"
+    return request
+

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,2 @@
+"""Integration tests for langsmith-mcp-server."""
+

--- a/tests/integration/test_http_transport.py
+++ b/tests/integration/test_http_transport.py
@@ -1,0 +1,177 @@
+"""Integration tests for HTTP transport."""
+
+import pytest
+from unittest.mock import Mock, patch, AsyncMock
+from starlette.testclient import TestClient
+from langsmith_mcp_server.server import app
+
+
+@pytest.fixture
+def client():
+    """Create a test client for the FastAPI app."""
+    return TestClient(app)
+
+
+class TestHTTPTransport:
+    """Integration tests for HTTP transport."""
+    
+    def test_health_check_endpoint(self, client):
+        """Test that health check endpoint works without authentication."""
+        # Execute
+        response = client.get("/health")
+        
+        # Verify
+        assert response.status_code == 200
+        assert "LangSmith MCP server is running" in response.text
+    
+    def test_mcp_endpoint_requires_auth(self, client):
+        """Test that MCP endpoint requires authentication."""
+        # Execute - no API key provided
+        response = client.post("/mcp", json={"test": "data"})
+        
+        # Verify
+        assert response.status_code == 401
+        assert "LANGSMITH-API-KEY" in response.json()["error"]
+    
+    def test_mcp_endpoint_with_valid_auth(self, client, sample_api_key):
+        """Test that MCP endpoint accepts valid API key."""
+        # Setup
+        headers = {"LANGSMITH-API-KEY": sample_api_key}
+        
+        # Note: This will fail with invalid JSON-RPC format but should pass auth
+        # Execute
+        response = client.post(
+            "/mcp",
+            json={"jsonrpc": "2.0", "method": "test", "id": 1},
+            headers=headers
+        )
+        
+        # Verify - should not be 401 (may be other error, but auth passed)
+        assert response.status_code != 401
+    
+    def test_mcp_endpoint_with_optional_headers(
+        self, client, sample_api_key, sample_workspace_id
+    ):
+        """Test that optional headers are accepted."""
+        # Setup
+        headers = {
+            "LANGSMITH-API-KEY": sample_api_key,
+            "LANGSMITH-WORKSPACE-ID": sample_workspace_id,
+            "LANGSMITH-ENDPOINT": "https://custom.api.com"
+        }
+        
+        # Execute
+        response = client.post(
+            "/mcp",
+            json={"jsonrpc": "2.0", "method": "test", "id": 1},
+            headers=headers
+        )
+        
+        # Verify - auth should pass
+        assert response.status_code != 401
+    
+    def test_cors_headers_present(self, client, sample_api_key):
+        """Test that CORS headers are properly set."""
+        # Setup
+        headers = {"LANGSMITH-API-KEY": sample_api_key, "Origin": "http://localhost:3000"}
+        
+        # Execute
+        response = client.options("/mcp", headers=headers)
+        
+        # Verify - CORS headers should be present
+        # The exact headers depend on CORS middleware configuration
+        assert response.status_code in [200, 204, 401]  # OPTIONS request handling
+    
+    @patch("langsmith_mcp_server.services.tools.prompts.Client")
+    def test_list_prompts_via_http(self, mock_client_class, client, sample_api_key):
+        """Test calling list_prompts tool via HTTP transport."""
+        # Setup
+        mock_client = Mock()
+        mock_client.list_prompts.return_value = []
+        mock_client_class.return_value = mock_client
+        
+        headers = {"LANGSMITH-API-KEY": sample_api_key}
+        
+        # This is a simplified test - actual MCP protocol is more complex
+        # But we're testing that the HTTP layer works
+        
+        # For now, just verify auth works and endpoint is reachable
+        response = client.post(
+            "/mcp",
+            json={"jsonrpc": "2.0", "method": "test", "id": 1},
+            headers=headers
+        )
+        
+        # Verify
+        assert response.status_code != 401  # Auth passed
+
+
+class TestHTTPTransportErrors:
+    """Test error handling in HTTP transport."""
+    
+    def test_invalid_json_returns_error(self, client, sample_api_key):
+        """Test that invalid JSON returns proper error."""
+        # Setup
+        headers = {"LANGSMITH-API-KEY": sample_api_key}
+        
+        # Execute - send invalid JSON
+        response = client.post(
+            "/mcp",
+            data="invalid json",
+            headers=headers
+        )
+        
+        # Verify - should return error (not 401)
+        assert response.status_code != 401
+        assert response.status_code in [400, 422, 500]  # Client or server error
+    
+    def test_empty_request_returns_error(self, client, sample_api_key):
+        """Test that empty request returns proper error."""
+        # Setup
+        headers = {"LANGSMITH-API-KEY": sample_api_key}
+        
+        # Execute
+        response = client.post("/mcp", json={}, headers=headers)
+        
+        # Verify
+        assert response.status_code != 401
+
+
+class TestHTTPTransportPerformance:
+    """Performance-related tests for HTTP transport."""
+    
+    def test_health_check_is_fast(self, client):
+        """Test that health check responds quickly."""
+        import time
+        
+        # Execute
+        start = time.time()
+        response = client.get("/health")
+        duration = time.time() - start
+        
+        # Verify
+        assert response.status_code == 200
+        assert duration < 1.0  # Should respond in less than 1 second
+    
+    def test_concurrent_requests_handled(self, client, sample_api_key):
+        """Test that multiple concurrent requests can be handled."""
+        import concurrent.futures
+        
+        headers = {"LANGSMITH-API-KEY": sample_api_key}
+        
+        def make_request():
+            return client.post(
+                "/mcp",
+                json={"jsonrpc": "2.0", "method": "test", "id": 1},
+                headers=headers
+            )
+        
+        # Execute multiple requests concurrently
+        with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
+            futures = [executor.submit(make_request) for _ in range(10)]
+            results = [f.result() for f in futures]
+        
+        # Verify all requests completed (not necessarily successfully, but no crashes)
+        assert len(results) == 10
+        assert all(r.status_code != 500 for r in results)  # No server errors
+

--- a/tests/integration/test_stdio_transport.py
+++ b/tests/integration/test_stdio_transport.py
@@ -1,0 +1,265 @@
+"""Integration tests for stdio transport."""
+
+import pytest
+import json
+import os
+from unittest.mock import Mock, patch, MagicMock
+from io import StringIO
+
+
+class TestStdioTransport:
+    """Integration tests for stdio transport."""
+    
+    @patch("langsmith_mcp_server.server.mcp")
+    def test_stdio_server_initialization(self, mock_mcp):
+        """Test that stdio server can be initialized."""
+        # Setup
+        from langsmith_mcp_server.server import main
+        
+        # Mock the run method to avoid actually starting the server
+        mock_mcp.run = Mock()
+        
+        # Execute
+        main()
+        
+        # Verify
+        mock_mcp.run.assert_called_once_with(transport="stdio")
+    
+    @patch.dict(os.environ, {"LANGSMITH_API_KEY": "lsv2_pt_test_key"})
+    def test_stdio_with_env_variables(self):
+        """Test that stdio transport uses environment variables."""
+        # Setup
+        api_key = os.environ.get("LANGSMITH_API_KEY")
+        
+        # Verify
+        assert api_key is not None
+        assert api_key.startswith("lsv2_")
+    
+    @patch.dict(os.environ, {}, clear=True)
+    def test_stdio_without_env_variables(self):
+        """Test stdio transport behavior without environment variables."""
+        # This should still work since stdio transport can work without API key
+        # (it's not required for the server to start, only for making API calls)
+        
+        api_key = os.environ.get("LANGSMITH_API_KEY")
+        
+        # Verify
+        assert api_key is None
+        # Server should still be able to start (it just won't be able to make API calls)
+
+
+class TestStdioMCPProtocol:
+    """Tests for MCP protocol over stdio."""
+    
+    def test_json_rpc_request_format(self):
+        """Test that requests follow JSON-RPC 2.0 format."""
+        # Setup - a valid MCP request
+        request = {
+            "jsonrpc": "2.0",
+            "method": "tools/list",
+            "id": 1
+        }
+        
+        # Verify structure
+        assert "jsonrpc" in request
+        assert request["jsonrpc"] == "2.0"
+        assert "method" in request
+        assert "id" in request
+    
+    def test_json_rpc_response_format(self):
+        """Test that responses follow JSON-RPC 2.0 format."""
+        # Setup - a valid MCP response
+        response = {
+            "jsonrpc": "2.0",
+            "result": {"tools": []},
+            "id": 1
+        }
+        
+        # Verify structure
+        assert "jsonrpc" in response
+        assert response["jsonrpc"] == "2.0"
+        assert "result" in response or "error" in response
+        assert "id" in response
+    
+    def test_json_rpc_error_format(self):
+        """Test error response format."""
+        # Setup - an error response
+        error_response = {
+            "jsonrpc": "2.0",
+            "error": {
+                "code": -32600,
+                "message": "Invalid Request"
+            },
+            "id": None
+        }
+        
+        # Verify structure
+        assert "jsonrpc" in error_response
+        assert "error" in error_response
+        assert "code" in error_response["error"]
+        assert "message" in error_response["error"]
+
+
+class TestStdioToolInvocation:
+    """Tests for tool invocation via stdio."""
+    
+    @patch("langsmith_mcp_server.common.helpers.get_client_from_context")
+    def test_list_prompts_tool_invocation(self, mock_get_client):
+        """Test invoking list_prompts tool via stdio transport."""
+        # Setup
+        mock_client = Mock()
+        mock_client.list_prompts.return_value = []
+        mock_get_client.return_value = mock_client
+        
+        from langsmith_mcp_server.services.tools.prompts import list_prompts_tool
+        
+        # Execute
+        result = list_prompts_tool(mock_client, is_public=False, limit=10)
+        
+        # Verify
+        assert "prompts" in result
+        assert isinstance(result["prompts"], list)
+    
+    @patch("langsmith_mcp_server.common.helpers.get_client_from_context")
+    def test_list_datasets_tool_invocation(self, mock_get_client):
+        """Test invoking list_datasets tool via stdio transport."""
+        # Setup
+        mock_client = Mock()
+        mock_client.list_datasets.return_value = []
+        mock_get_client.return_value = mock_client
+        
+        from langsmith_mcp_server.services.tools.datasets import list_datasets_tool
+        
+        # Execute
+        result = list_datasets_tool(mock_client, limit=10)
+        
+        # Verify
+        assert "datasets" in result
+        assert isinstance(result["datasets"], list)
+
+
+class TestStdioErrorHandling:
+    """Tests for error handling in stdio transport."""
+    
+    def test_invalid_json_input(self):
+        """Test handling of invalid JSON input."""
+        # Setup
+        invalid_json = "not a json string"
+        
+        # Verify that json.loads raises an error
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(invalid_json)
+    
+    def test_missing_required_fields(self):
+        """Test handling of requests with missing required fields."""
+        # Setup - request without required 'method' field
+        incomplete_request = {
+            "jsonrpc": "2.0",
+            "id": 1
+            # Missing 'method' field
+        }
+        
+        # Verify structure
+        assert "method" not in incomplete_request
+        # MCP server should handle this gracefully with an error response
+    
+    @patch("langsmith_mcp_server.common.helpers.get_client_from_context")
+    def test_tool_execution_error(self, mock_get_client):
+        """Test handling of errors during tool execution."""
+        # Setup
+        mock_client = Mock()
+        mock_client.list_prompts.side_effect = Exception("API error")
+        mock_get_client.return_value = mock_client
+        
+        from langsmith_mcp_server.services.tools.prompts import list_prompts_tool
+        
+        # Execute
+        result = list_prompts_tool(mock_client, is_public=False, limit=10)
+        
+        # Verify error is caught and returned
+        assert "error" in result
+        assert "API error" in result["error"]
+
+
+class TestStdioContextManagement:
+    """Tests for context management in stdio transport."""
+    
+    def test_context_state_storage(self, mock_context):
+        """Test that context can store and retrieve state."""
+        # Setup
+        test_key = "test_key"
+        test_value = "test_value"
+        
+        # Execute
+        mock_context.set_state(test_key, test_value)
+        retrieved_value = mock_context.get_state(test_key)
+        
+        # Verify
+        assert retrieved_value == test_value
+    
+    def test_context_state_default_value(self, mock_context):
+        """Test that context returns default value for missing keys."""
+        # Execute
+        retrieved_value = mock_context.get_state("nonexistent_key", "default")
+        
+        # Verify
+        assert retrieved_value == "default"
+    
+    @patch.dict(os.environ, {"LANGSMITH_API_KEY": "lsv2_pt_test_key"})
+    def test_context_environment_integration(self):
+        """Test that context integrates with environment variables."""
+        # Setup - environment variable is set
+        api_key = os.environ.get("LANGSMITH_API_KEY")
+        
+        # Verify
+        assert api_key == "lsv2_pt_test_key"
+        # In stdio transport, the server reads from environment
+
+
+class TestStdioPerformance:
+    """Performance tests for stdio transport."""
+    
+    @patch("langsmith_mcp_server.common.helpers.get_client_from_context")
+    def test_tool_response_time(self, mock_get_client):
+        """Test that tool responses are fast enough."""
+        import time
+        
+        # Setup
+        mock_client = Mock()
+        mock_client.list_prompts.return_value = []
+        mock_get_client.return_value = mock_client
+        
+        from langsmith_mcp_server.services.tools.prompts import list_prompts_tool
+        
+        # Execute
+        start = time.time()
+        result = list_prompts_tool(mock_client, is_public=False, limit=10)
+        duration = time.time() - start
+        
+        # Verify
+        assert "prompts" in result
+        assert duration < 1.0  # Should complete in less than 1 second (with mocked client)
+    
+    @patch("langsmith_mcp_server.common.helpers.get_client_from_context")
+    def test_sequential_tool_calls(self, mock_get_client):
+        """Test multiple sequential tool calls."""
+        # Setup
+        mock_client = Mock()
+        mock_client.list_prompts.return_value = []
+        mock_client.list_datasets.return_value = []
+        mock_get_client.return_value = mock_client
+        
+        from langsmith_mcp_server.services.tools.prompts import list_prompts_tool
+        from langsmith_mcp_server.services.tools.datasets import list_datasets_tool
+        
+        # Execute multiple calls
+        results = []
+        for _ in range(5):
+            result1 = list_prompts_tool(mock_client, is_public=False, limit=10)
+            result2 = list_datasets_tool(mock_client, limit=10)
+            results.extend([result1, result2])
+        
+        # Verify all succeeded
+        assert len(results) == 10
+        assert all("prompts" in r or "datasets" in r for r in results)
+

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,0 +1,155 @@
+"""Tests for middleware components."""
+
+import pytest
+from unittest.mock import Mock, AsyncMock, patch
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.status import HTTP_401_UNAUTHORIZED
+from langsmith_mcp_server.middleware import APIKeyMiddleware
+
+
+class TestAPIKeyMiddleware:
+    """Tests for APIKeyMiddleware."""
+    
+    @pytest.mark.asyncio
+    async def test_health_check_bypasses_auth(self):
+        """Test that health check endpoint bypasses authentication."""
+        # Setup
+        middleware = APIKeyMiddleware(app=Mock())
+        
+        request = Mock(spec=Request)
+        request.url = Mock()
+        request.url.path = "/health"
+        request.headers = {}
+        
+        call_next = AsyncMock(return_value=JSONResponse({"status": "ok"}))
+        
+        # Execute
+        response = await middleware.dispatch(request, call_next)
+        
+        # Verify
+        assert call_next.called
+        assert response.status_code == 200
+    
+    @pytest.mark.asyncio
+    async def test_missing_api_key_returns_401(self):
+        """Test that missing API key returns 401."""
+        # Setup
+        middleware = APIKeyMiddleware(app=Mock())
+        
+        request = Mock(spec=Request)
+        request.url = Mock()
+        request.url.path = "/mcp"
+        request.headers = {}
+        
+        def get_header(key, default=None):
+            return request.headers.get(key, default)
+        
+        request.headers.get = get_header
+        
+        call_next = AsyncMock()
+        
+        # Execute
+        response = await middleware.dispatch(request, call_next)
+        
+        # Verify
+        assert isinstance(response, JSONResponse)
+        assert response.status_code == HTTP_401_UNAUTHORIZED
+        assert not call_next.called
+    
+    @pytest.mark.asyncio
+    async def test_valid_api_key_sets_state(self, sample_api_key):
+        """Test that valid API key sets request state."""
+        # Setup
+        middleware = APIKeyMiddleware(app=Mock())
+        
+        request = Mock(spec=Request)
+        request.url = Mock()
+        request.url.path = "/mcp"
+        request.headers = {"LANGSMITH-API-KEY": sample_api_key}
+        request.state = Mock()
+        
+        def get_header(key, default=None):
+            return request.headers.get(key, default)
+        
+        request.headers.get = get_header
+        
+        call_next = AsyncMock(return_value=JSONResponse({"status": "ok"}))
+        
+        # Execute
+        response = await middleware.dispatch(request, call_next)
+        
+        # Verify
+        assert call_next.called
+        assert request.state.api_key == sample_api_key
+        assert hasattr(request.state, "workspace_id")
+        assert hasattr(request.state, "endpoint")
+    
+    @pytest.mark.asyncio
+    async def test_optional_headers_extracted(self, sample_api_key, sample_workspace_id):
+        """Test that optional headers are properly extracted."""
+        # Setup
+        middleware = APIKeyMiddleware(app=Mock())
+        
+        request = Mock(spec=Request)
+        request.url = Mock()
+        request.url.path = "/mcp"
+        request.headers = {
+            "LANGSMITH-API-KEY": sample_api_key,
+            "LANGSMITH-WORKSPACE-ID": sample_workspace_id,
+            "LANGSMITH-ENDPOINT": "https://custom.api.com"
+        }
+        request.state = Mock()
+        
+        def get_header(key, default=None):
+            return request.headers.get(key, default)
+        
+        request.headers.get = get_header
+        
+        call_next = AsyncMock(return_value=JSONResponse({"status": "ok"}))
+        
+        # Execute
+        response = await middleware.dispatch(request, call_next)
+        
+        # Verify
+        assert request.state.api_key == sample_api_key
+        assert request.state.workspace_id == sample_workspace_id
+        assert request.state.endpoint == "https://custom.api.com"
+    
+    @pytest.mark.asyncio
+    async def test_context_variables_set_and_cleared(self, sample_api_key):
+        """Test that context variables are set during request and cleared after."""
+        # Setup
+        middleware = APIKeyMiddleware(app=Mock())
+        
+        request = Mock(spec=Request)
+        request.url = Mock()
+        request.url.path = "/mcp"
+        request.headers = {"LANGSMITH-API-KEY": sample_api_key}
+        request.state = Mock()
+        
+        def get_header(key, default=None):
+            return request.headers.get(key, default)
+        
+        request.headers.get = get_header
+        
+        # Capture context variable values during call_next
+        captured_api_key = None
+        
+        async def call_next_with_capture(req):
+            nonlocal captured_api_key
+            from langsmith_mcp_server.middleware import api_key_context
+            captured_api_key = api_key_context.get("")
+            return JSONResponse({"status": "ok"})
+        
+        # Execute
+        response = await middleware.dispatch(request, call_next_with_capture)
+        
+        # Verify
+        # During request, context variable should be set
+        assert captured_api_key == sample_api_key
+        
+        # After request, context variables should be cleared
+        from langsmith_mcp_server.middleware import api_key_context
+        assert api_key_context.get("") == ""
+

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -1,7 +1,0 @@
-"""
-Placeholder for tests
-"""
-
-
-def test_mock():
-    assert True

--- a/tests/tools/test_datasets.py
+++ b/tests/tools/test_datasets.py
@@ -1,0 +1,242 @@
+"""Tests for dataset tools."""
+
+import pytest
+from unittest.mock import Mock
+from langsmith_mcp_server.services.tools.datasets import (
+    list_datasets_tool,
+    list_examples_tool,
+    read_dataset_tool,
+    read_example_tool,
+)
+
+
+class TestListDatasetsTool:
+    """Tests for list_datasets_tool."""
+    
+    def test_list_datasets_success(self, mock_langsmith_client, mock_dataset):
+        """Test successful list of datasets."""
+        # Setup
+        mock_langsmith_client.list_datasets.return_value = [mock_dataset]
+        
+        # Execute
+        result = list_datasets_tool(mock_langsmith_client, limit=10)
+        
+        # Verify
+        assert "datasets" in result
+        assert len(result["datasets"]) == 1
+        assert result["datasets"][0]["name"] == "test-dataset"
+        assert "total_count" in result
+        assert result["total_count"] == 1
+    
+    def test_list_datasets_empty(self, mock_langsmith_client):
+        """Test list datasets with no results."""
+        # Setup
+        mock_langsmith_client.list_datasets.return_value = []
+        
+        # Execute
+        result = list_datasets_tool(mock_langsmith_client, limit=10)
+        
+        # Verify
+        assert "datasets" in result
+        assert len(result["datasets"]) == 0
+        assert result["total_count"] == 0
+    
+    def test_list_datasets_with_filters(self, mock_langsmith_client, mock_dataset):
+        """Test list datasets with various filters."""
+        # Setup
+        mock_langsmith_client.list_datasets.return_value = [mock_dataset]
+        
+        # Execute
+        result = list_datasets_tool(
+            mock_langsmith_client,
+            data_type="kv",
+            dataset_name="test-dataset",
+            limit=5
+        )
+        
+        # Verify
+        assert "datasets" in result
+        assert len(result["datasets"]) == 1
+        mock_langsmith_client.list_datasets.assert_called_once()
+    
+    def test_list_datasets_error(self, mock_langsmith_client):
+        """Test list datasets with error."""
+        # Setup
+        mock_langsmith_client.list_datasets.side_effect = Exception("API error")
+        
+        # Execute
+        result = list_datasets_tool(mock_langsmith_client, limit=10)
+        
+        # Verify
+        assert "error" in result
+        assert "API error" in result["error"]
+
+
+class TestListExamplesTool:
+    """Tests for list_examples_tool."""
+    
+    def test_list_examples_success(self, mock_langsmith_client, mock_example):
+        """Test successful list of examples."""
+        # Setup
+        mock_langsmith_client.list_examples.return_value = [mock_example]
+        
+        # Execute
+        result = list_examples_tool(
+            mock_langsmith_client,
+            dataset_name="test-dataset",
+            limit=10
+        )
+        
+        # Verify
+        assert "examples" in result
+        assert len(result["examples"]) == 1
+        assert result["examples"][0]["inputs"]["question"] == "What is the capital of France?"
+        assert "total_count" in result
+    
+    def test_list_examples_with_dataset_id(self, mock_langsmith_client, mock_example):
+        """Test list examples with dataset ID."""
+        # Setup
+        mock_langsmith_client.list_examples.return_value = [mock_example]
+        dataset_id = str(mock_example.dataset_id)
+        
+        # Execute
+        result = list_examples_tool(
+            mock_langsmith_client,
+            dataset_id=dataset_id,
+            limit=5
+        )
+        
+        # Verify
+        assert "examples" in result
+        assert len(result["examples"]) == 1
+    
+    def test_list_examples_empty(self, mock_langsmith_client):
+        """Test list examples with no results."""
+        # Setup
+        mock_langsmith_client.list_examples.return_value = []
+        
+        # Execute
+        result = list_examples_tool(
+            mock_langsmith_client,
+            dataset_name="empty-dataset",
+            limit=10
+        )
+        
+        # Verify
+        assert "examples" in result
+        assert len(result["examples"]) == 0
+    
+    def test_list_examples_error(self, mock_langsmith_client):
+        """Test list examples with error."""
+        # Setup
+        mock_langsmith_client.list_examples.side_effect = Exception("Dataset not found")
+        
+        # Execute
+        result = list_examples_tool(
+            mock_langsmith_client,
+            dataset_name="nonexistent",
+            limit=10
+        )
+        
+        # Verify
+        assert "error" in result
+        assert "Dataset not found" in result["error"]
+
+
+class TestReadDatasetTool:
+    """Tests for read_dataset_tool."""
+    
+    def test_read_dataset_by_id(self, mock_langsmith_client, mock_dataset):
+        """Test reading dataset by ID."""
+        # Setup
+        mock_langsmith_client.read_dataset.return_value = mock_dataset
+        dataset_id = str(mock_dataset.id)
+        
+        # Execute
+        result = read_dataset_tool(mock_langsmith_client, dataset_id=dataset_id)
+        
+        # Verify
+        assert "dataset" in result
+        assert result["dataset"]["name"] == "test-dataset"
+        assert result["dataset"]["data_type"] == "kv"
+    
+    def test_read_dataset_by_name(self, mock_langsmith_client, mock_dataset):
+        """Test reading dataset by name."""
+        # Setup
+        mock_langsmith_client.read_dataset.return_value = mock_dataset
+        
+        # Execute
+        result = read_dataset_tool(
+            mock_langsmith_client,
+            dataset_name="test-dataset"
+        )
+        
+        # Verify
+        assert "dataset" in result
+        assert result["dataset"]["name"] == "test-dataset"
+    
+    def test_read_dataset_error(self, mock_langsmith_client):
+        """Test read dataset with error."""
+        # Setup
+        mock_langsmith_client.read_dataset.side_effect = Exception("Dataset not found")
+        
+        # Execute
+        result = read_dataset_tool(
+            mock_langsmith_client,
+            dataset_name="nonexistent"
+        )
+        
+        # Verify
+        assert "error" in result
+        assert "Dataset not found" in result["error"]
+
+
+class TestReadExampleTool:
+    """Tests for read_example_tool."""
+    
+    def test_read_example_success(self, mock_langsmith_client, mock_example):
+        """Test reading example by ID."""
+        # Setup
+        mock_langsmith_client.read_example.return_value = mock_example
+        example_id = str(mock_example.id)
+        
+        # Execute
+        result = read_example_tool(mock_langsmith_client, example_id=example_id)
+        
+        # Verify
+        assert "example" in result
+        assert result["example"]["inputs"]["question"] == "What is the capital of France?"
+        assert result["example"]["outputs"]["answer"] == "Paris"
+    
+    def test_read_example_with_version(self, mock_langsmith_client, mock_example):
+        """Test reading example with version."""
+        # Setup
+        mock_langsmith_client.read_example.return_value = mock_example
+        example_id = str(mock_example.id)
+        
+        # Execute
+        result = read_example_tool(
+            mock_langsmith_client,
+            example_id=example_id,
+            as_of="v1.0"
+        )
+        
+        # Verify
+        assert "example" in result
+        assert "inputs" in result["example"]
+    
+    def test_read_example_error(self, mock_langsmith_client):
+        """Test read example with error."""
+        # Setup
+        mock_langsmith_client.read_example.side_effect = Exception("Example not found")
+        
+        # Execute
+        result = read_example_tool(
+            mock_langsmith_client,
+            example_id="nonexistent-id"
+        )
+        
+        # Verify
+        assert "error" in result
+        assert "Example not found" in result["error"]
+

--- a/tests/tools/test_prompts.py
+++ b/tests/tools/test_prompts.py
@@ -1,0 +1,130 @@
+"""Tests for prompt tools."""
+
+import pytest
+from unittest.mock import Mock, patch
+from langsmith_mcp_server.services.tools.prompts import (
+    list_prompts_tool,
+    get_prompt_tool,
+)
+
+
+class TestListPromptsTool:
+    """Tests for list_prompts_tool."""
+    
+    def test_list_prompts_success(self, mock_langsmith_client, mock_prompt):
+        """Test successful list of prompts."""
+        # Setup
+        mock_langsmith_client.list_prompts.return_value = [mock_prompt]
+        
+        # Execute
+        result = list_prompts_tool(mock_langsmith_client, is_public=False, limit=10)
+        
+        # Verify
+        assert "prompts" in result
+        assert len(result["prompts"]) == 1
+        assert result["prompts"][0]["name"] == "test-prompt"
+        mock_langsmith_client.list_prompts.assert_called_once()
+    
+    def test_list_prompts_empty(self, mock_langsmith_client):
+        """Test list prompts with no results."""
+        # Setup
+        mock_langsmith_client.list_prompts.return_value = []
+        
+        # Execute
+        result = list_prompts_tool(mock_langsmith_client, is_public=True, limit=20)
+        
+        # Verify
+        assert "prompts" in result
+        assert len(result["prompts"]) == 0
+    
+    def test_list_prompts_error(self, mock_langsmith_client):
+        """Test list prompts with error."""
+        # Setup
+        mock_langsmith_client.list_prompts.side_effect = Exception("API error")
+        
+        # Execute
+        result = list_prompts_tool(mock_langsmith_client, is_public=False, limit=10)
+        
+        # Verify
+        assert "error" in result
+        assert "API error" in result["error"]
+    
+    def test_list_prompts_with_multiple_prompts(self, mock_langsmith_client, mock_prompt):
+        """Test list prompts with multiple results."""
+        # Setup
+        prompt1 = Mock()
+        prompt1.name = "prompt-1"
+        prompt1.id = "id-1"
+        prompt1.is_public = False
+        prompt1.description = "Description 1"
+        prompt1.created_at = mock_prompt.created_at
+        prompt1.updated_at = mock_prompt.updated_at
+        prompt1.prompt = {"messages": []}
+        
+        prompt2 = Mock()
+        prompt2.name = "prompt-2"
+        prompt2.id = "id-2"
+        prompt2.is_public = True
+        prompt2.description = "Description 2"
+        prompt2.created_at = mock_prompt.created_at
+        prompt2.updated_at = mock_prompt.updated_at
+        prompt2.prompt = {"messages": []}
+        
+        mock_langsmith_client.list_prompts.return_value = [prompt1, prompt2]
+        
+        # Execute
+        result = list_prompts_tool(mock_langsmith_client, is_public=False, limit=10)
+        
+        # Verify
+        assert len(result["prompts"]) == 2
+        assert result["prompts"][0]["name"] == "prompt-1"
+        assert result["prompts"][1]["name"] == "prompt-2"
+
+
+class TestGetPromptTool:
+    """Tests for get_prompt_tool."""
+    
+    def test_get_prompt_success(self, mock_langsmith_client, mock_prompt):
+        """Test successful get prompt by name."""
+        # Setup
+        mock_langsmith_client.pull_prompt.return_value = mock_prompt
+        
+        # Execute
+        result = get_prompt_tool(mock_langsmith_client, prompt_name="test-prompt")
+        
+        # Verify
+        assert "prompt" in result
+        assert result["prompt"]["name"] == "test-prompt"
+        mock_langsmith_client.pull_prompt.assert_called_once_with("test-prompt")
+    
+    def test_get_prompt_not_found(self, mock_langsmith_client):
+        """Test get prompt when prompt doesn't exist."""
+        # Setup
+        mock_langsmith_client.pull_prompt.side_effect = Exception("Prompt not found")
+        
+        # Execute
+        result = get_prompt_tool(mock_langsmith_client, prompt_name="nonexistent")
+        
+        # Verify
+        assert "error" in result
+        assert "Prompt not found" in result["error"]
+    
+    def test_get_prompt_with_template(self, mock_langsmith_client, mock_prompt):
+        """Test get prompt includes template information."""
+        # Setup
+        mock_prompt.prompt = {
+            "messages": [
+                {"role": "system", "content": "You are helpful"},
+                {"role": "user", "content": "{input}"}
+            ]
+        }
+        mock_langsmith_client.pull_prompt.return_value = mock_prompt
+        
+        # Execute
+        result = get_prompt_tool(mock_langsmith_client, prompt_name="test-prompt")
+        
+        # Verify
+        assert "prompt" in result
+        assert "prompt" in result["prompt"]
+        assert len(result["prompt"]["prompt"]["messages"]) == 2
+

--- a/tests/tools/test_traces.py
+++ b/tests/tools/test_traces.py
@@ -1,0 +1,357 @@
+"""Tests for trace tools."""
+
+import pytest
+from unittest.mock import Mock, patch
+from uuid import uuid4
+from langsmith_mcp_server.services.tools.traces import (
+    fetch_runs_tool,
+    list_projects_tool,
+    fetch_trace_tool,
+    get_thread_history_tool,
+    get_project_runs_stats_tool,
+)
+
+
+class TestFetchRunsTool:
+    """Tests for fetch_runs_tool."""
+    
+    def test_fetch_runs_success(self, mock_langsmith_client, mock_run):
+        """Test successful fetch of runs."""
+        # Setup
+        mock_langsmith_client.list_runs.return_value = [mock_run]
+        
+        # Execute
+        result = fetch_runs_tool(
+            mock_langsmith_client,
+            project_name="test-project",
+            limit=10
+        )
+        
+        # Verify
+        assert "runs" in result
+        assert len(result["runs"]) == 1
+        mock_langsmith_client.list_runs.assert_called_once()
+    
+    def test_fetch_runs_with_filters(self, mock_langsmith_client, mock_run):
+        """Test fetch runs with various filters."""
+        # Setup
+        mock_langsmith_client.list_runs.return_value = [mock_run]
+        
+        # Execute
+        result = fetch_runs_tool(
+            mock_langsmith_client,
+            project_name="test-project",
+            run_type="chain",
+            error=False,
+            is_root=True,
+            limit=5
+        )
+        
+        # Verify
+        assert "runs" in result
+        mock_langsmith_client.list_runs.assert_called_once()
+    
+    def test_fetch_runs_with_trace_id(self, mock_langsmith_client, mock_run):
+        """Test fetch runs with specific trace ID."""
+        # Setup
+        mock_langsmith_client.list_runs.return_value = [mock_run]
+        trace_id = str(uuid4())
+        
+        # Execute
+        result = fetch_runs_tool(
+            mock_langsmith_client,
+            project_name="test-project",
+            trace_id=trace_id,
+            limit=10
+        )
+        
+        # Verify
+        assert "runs" in result
+        mock_langsmith_client.list_runs.assert_called_once()
+    
+    def test_fetch_runs_formatted_output(self, mock_langsmith_client, mock_run):
+        """Test fetch runs with formatted output."""
+        # Setup
+        mock_run.inputs = {"messages": [{"role": "user", "content": "Hello"}]}
+        mock_run.outputs = {"messages": [{"role": "assistant", "content": "Hi"}]}
+        mock_langsmith_client.list_runs.return_value = [mock_run]
+        
+        # Execute
+        result = fetch_runs_tool(
+            mock_langsmith_client,
+            project_name="test-project",
+            limit=10,
+            format_type="pretty"
+        )
+        
+        # Verify
+        assert "formatted" in result
+        assert isinstance(result["formatted"], str)
+
+
+class TestListProjectsTool:
+    """Tests for list_projects_tool."""
+    
+    def test_list_projects_success(self, mock_langsmith_client, mock_project):
+        """Test successful list of projects."""
+        # Setup
+        mock_langsmith_client.list_projects.return_value = [mock_project]
+        
+        # Execute
+        result = list_projects_tool(mock_langsmith_client, limit=5)
+        
+        # Verify
+        assert "projects" in result
+        assert len(result["projects"]) == 1
+        assert result["projects"][0]["name"] == "test-project"
+    
+    def test_list_projects_with_name_filter(self, mock_langsmith_client, mock_project):
+        """Test list projects with name filter."""
+        # Setup
+        mock_langsmith_client.list_projects.return_value = [mock_project]
+        
+        # Execute
+        result = list_projects_tool(
+            mock_langsmith_client,
+            limit=10,
+            project_name="test"
+        )
+        
+        # Verify
+        assert "projects" in result
+        assert len(result["projects"]) == 1
+    
+    def test_list_projects_more_info(self, mock_langsmith_client, mock_project):
+        """Test list projects with more_info flag."""
+        # Setup
+        mock_langsmith_client.list_projects.return_value = [mock_project]
+        
+        # Execute
+        result = list_projects_tool(
+            mock_langsmith_client,
+            limit=5,
+            more_info=True
+        )
+        
+        # Verify
+        assert "projects" in result
+        assert len(result["projects"]) == 1
+        # With more_info, we get full project dict
+        assert "id" in result["projects"][0]
+    
+    def test_list_projects_empty(self, mock_langsmith_client):
+        """Test list projects with no results."""
+        # Setup
+        mock_langsmith_client.list_projects.return_value = []
+        
+        # Execute
+        result = list_projects_tool(mock_langsmith_client, limit=5)
+        
+        # Verify
+        assert "projects" in result
+        assert len(result["projects"]) == 0
+
+
+class TestFetchTraceTool:
+    """Tests for fetch_trace_tool."""
+    
+    def test_fetch_trace_by_id(self, mock_langsmith_client, mock_run):
+        """Test fetch trace by trace ID."""
+        # Setup
+        mock_langsmith_client.list_runs.return_value = [mock_run]
+        trace_id = str(uuid4())
+        
+        # Execute
+        result = fetch_trace_tool(
+            mock_langsmith_client,
+            trace_id=trace_id
+        )
+        
+        # Verify
+        assert "trace_id" in result
+        assert "run_type" in result
+        mock_langsmith_client.list_runs.assert_called_once()
+    
+    def test_fetch_trace_by_project(self, mock_langsmith_client, mock_run):
+        """Test fetch trace by project name."""
+        # Setup
+        mock_langsmith_client.list_runs.return_value = [mock_run]
+        
+        # Execute
+        result = fetch_trace_tool(
+            mock_langsmith_client,
+            project_name="test-project"
+        )
+        
+        # Verify
+        assert "trace_id" in result
+        assert "run_type" in result
+    
+    def test_fetch_trace_no_parameters(self, mock_langsmith_client):
+        """Test fetch trace with no parameters returns error."""
+        # Execute
+        result = fetch_trace_tool(mock_langsmith_client)
+        
+        # Verify
+        assert "error" in result
+        assert "project_name or trace_id must be provided" in result["error"]
+    
+    def test_fetch_trace_not_found(self, mock_langsmith_client):
+        """Test fetch trace when no runs found."""
+        # Setup
+        mock_langsmith_client.list_runs.return_value = []
+        
+        # Execute
+        result = fetch_trace_tool(
+            mock_langsmith_client,
+            project_name="nonexistent-project"
+        )
+        
+        # Verify
+        assert "error" in result
+        assert "No runs found" in result["error"]
+
+
+class TestGetThreadHistoryTool:
+    """Tests for get_thread_history_tool."""
+    
+    def test_get_thread_history_success(self, mock_langsmith_client, mock_run):
+        """Test successful get thread history."""
+        # Setup
+        mock_run.inputs = {
+            "messages": [
+                {"role": "user", "content": "Hello"}
+            ]
+        }
+        mock_run.outputs = {
+            "choices": [
+                {"message": {"role": "assistant", "content": "Hi there"}}
+            ]
+        }
+        mock_run.run_type = "llm"
+        mock_langsmith_client.list_runs.return_value = [mock_run]
+        
+        # Execute
+        result = get_thread_history_tool(
+            mock_langsmith_client,
+            thread_id="test-thread-id",
+            project_name="test-project"
+        )
+        
+        # Verify
+        assert "result" in result
+        assert isinstance(result["result"], list)
+        assert len(result["result"]) >= 1
+    
+    def test_get_thread_history_no_runs(self, mock_langsmith_client):
+        """Test get thread history when no runs found."""
+        # Setup
+        mock_langsmith_client.list_runs.return_value = []
+        
+        # Execute
+        result = get_thread_history_tool(
+            mock_langsmith_client,
+            thread_id="nonexistent-thread",
+            project_name="test-project"
+        )
+        
+        # Verify
+        assert "error" in result
+        assert "No runs found" in result["error"]
+    
+    def test_get_thread_history_no_messages(self, mock_langsmith_client, mock_run):
+        """Test get thread history when run has no messages."""
+        # Setup
+        mock_run.inputs = {}
+        mock_run.outputs = {}
+        mock_run.run_type = "llm"
+        mock_langsmith_client.list_runs.return_value = [mock_run]
+        
+        # Execute
+        result = get_thread_history_tool(
+            mock_langsmith_client,
+            thread_id="test-thread-id",
+            project_name="test-project"
+        )
+        
+        # Verify
+        assert "error" in result
+        assert "No messages found" in result["error"]
+
+
+class TestGetProjectRunsStatsTool:
+    """Tests for get_project_runs_stats_tool."""
+    
+    def test_get_project_runs_stats_success(self, mock_langsmith_client):
+        """Test successful get project runs stats."""
+        # Setup
+        mock_stats = {
+            "run_count": 100,
+            "avg_latency": 1.5,
+            "error_count": 5,
+            "total_tokens": 10000
+        }
+        mock_langsmith_client.get_run_stats.return_value = mock_stats
+        
+        # Execute
+        result = get_project_runs_stats_tool(
+            mock_langsmith_client,
+            project_name="test-project"
+        )
+        
+        # Verify
+        assert "run_count" in result
+        assert result["run_count"] == 100
+        assert "project_name" in result
+        assert result["project_name"] == "test-project"
+    
+    def test_get_project_runs_stats_by_trace_id(self, mock_langsmith_client):
+        """Test get project runs stats by trace ID."""
+        # Setup
+        mock_stats = {
+            "run_count": 10,
+            "avg_latency": 2.0
+        }
+        mock_langsmith_client.get_run_stats.return_value = mock_stats
+        trace_id = str(uuid4())
+        
+        # Execute
+        result = get_project_runs_stats_tool(
+            mock_langsmith_client,
+            project_name="test-project",
+            trace_id=trace_id
+        )
+        
+        # Verify
+        assert "run_count" in result
+        assert result["run_count"] == 10
+    
+    def test_get_project_runs_stats_no_parameters(self, mock_langsmith_client):
+        """Test get project runs stats with no parameters returns error."""
+        # Execute
+        result = get_project_runs_stats_tool(mock_langsmith_client)
+        
+        # Verify
+        assert "error" in result
+        assert "project_name or trace_id must be provided" in result["error"]
+    
+    def test_get_project_runs_stats_qualified_name(self, mock_langsmith_client):
+        """Test get project runs stats with qualified project name."""
+        # Setup
+        mock_stats = {
+            "run_count": 50,
+            "avg_latency": 1.8
+        }
+        mock_langsmith_client.get_run_stats.return_value = mock_stats
+        
+        # Execute
+        result = get_project_runs_stats_tool(
+            mock_langsmith_client,
+            project_name="owner/test-project"
+        )
+        
+        # Verify
+        assert "run_count" in result
+        assert "project_name" in result
+        assert result["project_name"] == "test-project"  # Should strip owner prefix
+


### PR DESCRIPTION
## What's this about?

Closes #29

So I went through the codebase and... yeah, we basically had one test file that just did `assert True`. Not exactly confidence-inspiring when you're making changes, right?

This PR sets up a proper testing foundation so we can actually know when we break stuff.

## What I added

**Test fixtures (`tests/conftest.py`):**
- Mock LangSmith client that we can use everywhere
- Mock objects for prompts, datasets, examples, runs, projects
- Mock context and HTTP request helpers
- Sample API keys and workspace IDs for testing

**Unit tests for tools:**
- `test_prompts.py` - tests for list_prompts and get_prompt_by_name
- `test_datasets.py` - tests for all dataset/example operations
- `test_traces.py` - tests for fetch_runs, list_projects, thread history, etc.

**Middleware tests:**
- `test_middleware.py` - API key validation, context handling, auth bypass for health check

**Integration tests:**
- HTTP transport tests - auth flow, CORS, concurrent requests
- Stdio transport tests - protocol format, tool invocation, error handling

## Also

Deleted `test_mock.py` because... well, it wasn't really doing anything useful.

## Testing

All tests are designed to run without hitting the real LangSmith API (mocked). Just run:

make testor

uv run pytest tests/ -v---

Let me know if anything looks off or if I missed a tool that should have tests!