### PR TITLE
fix: use Optional type hints for nullable params to prevent null defaults in MCP schema

### DIFF
--- a/langsmith_mcp_server/services/register_tools.py
+++ b/langsmith_mcp_server/services/register_tools.py
@@ -304,9 +304,9 @@ You can create a reusable helper function:
 def push_prompt_to_langsmith(
     prompt,
     prompt_identifier: str,
-    description: str = None,
+    description: str | None = None,
     tags: list = None,
-    is_public: bool = None,
+    is_public: bool | None = None,
 ) -> str:
     '''
     Push a prompt to LangSmith with optional metadata.
@@ -442,15 +442,15 @@ client = Client()  # Will automatically use environment variables
         project_name: str,
         limit: int,
         page_number: int = 1,
-        trace_id: str = None,
-        run_type: str = None,
-        error: str = None,
-        is_root: str = None,
-        filter: str = None,
-        trace_filter: str = None,
-        tree_filter: str = None,
+        trace_id: str | None = None,
+        run_type: str | None = None,
+        error: str | None = None,
+        is_root: str | None = None,
+        filter: str | None = None,
+        trace_filter: str | None = None,
+        tree_filter: str | None = None,
         order_by: str = "-start_time",
-        reference_example_id: str = None,
+        reference_example_id: str | None = None,
         max_chars_per_page: int = 25000,
         preview_chars: int = 150,
         ctx: Context = None,
@@ -615,10 +615,10 @@ client = Client()  # Will automatically use environment variables
     @mcp.tool()
     async def list_projects(
         limit: int = 5,
-        project_name: str = None,
+        project_name: str | None = None,
         more_info: str = "false",
-        reference_dataset_id: str = None,
-        reference_dataset_name: str = None,
+        reference_dataset_id: str | None = None,
+        reference_dataset_name: str | None = None,
         ctx: Context = None,
     ) -> Dict[str, Any]:
         """

--- a/langsmith_mcp_server/services/tools/datasets.py
+++ b/langsmith_mcp_server/services/tools/datasets.py
@@ -10,9 +10,9 @@ from langsmith_mcp_server.common.helpers import _parse_as_of_parameter
 def list_datasets_tool(
     client: Client,
     dataset_ids: list = None,
-    data_type: str = None,
-    dataset_name: str = None,
-    dataset_name_contains: str = None,
+    data_type: str | None = None,
+    dataset_name: str | None = None,
+    dataset_name_contains: str | None = None,
     metadata: dict = None,
     limit: int = 20,
 ) -> Dict[str, Any]:
@@ -87,17 +87,17 @@ def list_datasets_tool(
 
 def list_examples_tool(
     client: Client,
-    dataset_id: str = None,
-    dataset_name: str = None,
+    dataset_id: str | None = None,
+    dataset_name: str | None = None,
     example_ids: list = None,
-    filter: str = None,
+    filter: str | None = None,
     metadata: dict = None,
     splits: list = None,
-    inline_s3_urls: bool = None,
-    include_attachments: bool = None,
-    as_of: str = None,
-    limit: int = None,
-    offset: int = None,
+    inline_s3_urls: bool | None = None,
+    include_attachments: bool | None = None,
+    as_of: str | None = None,
+    limit: int | None = None,
+    offset: int | None = None,
 ) -> Dict[str, Any]:
     """
     Fetch examples from a LangSmith dataset.
@@ -184,8 +184,8 @@ def list_examples_tool(
 
 def read_dataset_tool(
     client: Client,
-    dataset_id: str = None,
-    dataset_name: str = None,
+    dataset_id: str | None = None,
+    dataset_name: str | None = None,
 ) -> Dict[str, Any]:
     """
     Read a specific dataset from LangSmith.
@@ -247,7 +247,7 @@ def read_dataset_tool(
 def read_example_tool(
     client: Client,
     example_id: str,
-    as_of: str = None,
+    as_of: str | None = None,
 ) -> Dict[str, Any]:
     """
     Read a specific example from LangSmith.

--- a/langsmith_mcp_server/services/tools/prompts.py
+++ b/langsmith_mcp_server/services/tools/prompts.py
@@ -58,7 +58,7 @@ def list_prompts_tool(client: Client, is_public: bool = False, limit: int = 20) 
         return {"error": f"Error fetching prompts: {str(e)}"}
 
 
-def get_prompt_tool(client: Client, prompt_name: str = None, prompt_id: str = None) -> dict:
+def get_prompt_tool(client: Client, prompt_name: str | None = None, prompt_id: str | None = None) -> dict:
     """
     Get a specific prompt (including model/tool bindings) by its name or ID, and return its full
     string representation.

--- a/langsmith_mcp_server/services/tools/traces.py
+++ b/langsmith_mcp_server/services/tools/traces.py
@@ -37,7 +37,7 @@ except ImportError:
 
 
 def fetch_trace_tool(
-    client: Client, project_name: str = None, trace_id: str = None
+    client: Client, project_name: str | None = None, trace_id: str | None = None
 ) -> Dict[str, Any]:
     """
     Fetch the trace content for a specific project or specify a trace ID.
@@ -194,8 +194,8 @@ def get_thread_history_tool(
 
 def get_project_runs_stats_tool(
     client: Client,
-    project_name: str = None,
-    trace_id: str = None,
+    project_name: str | None = None,
+    trace_id: str | None = None,
 ) -> Dict[str, Any]:
     """
     Get the project runs stats.
@@ -243,10 +243,10 @@ def get_project_runs_stats_tool(
 def list_projects_tool(
     client: Client,
     limit: int = 5,
-    project_name: str = None,
+    project_name: str | None = None,
     more_info: bool = False,
-    reference_dataset_id: str = None,
-    reference_dataset_name: str = None,
+    reference_dataset_id: str | None = None,
+    reference_dataset_name: str | None = None,
 ) -> Dict[str, Any]:
     """
     List projects from LangSmith.


### PR DESCRIPTION
## Problem

Parameters declared as `param: str = None` produce JSON Schema with `"type": "string", "default": null`. MCP clients (e.g., [mcporter](https://github.com/steipete/mcporter)) auto-fill schema defaults when the user doesn't provide a value, sending `null` to the server — which then rejects them with pydantic validation errors:

```
3 validation errors for call[list_projects]
project_name
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
reference_dataset_id
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
```

This affects any MCP client that auto-fills defaults from the tool schema.

## Schema before (broken)

```json
{
  "project_name": {
    "type": "string",
    "default": null
  }
}
```

`null` is not a valid value for `type: "string"`, and clients that honor the default send `null`, causing validation failures.

## Fix

Change `str = None` → `str | None = None` across all tool functions and registration wrappers. This produces proper `anyOf` schemas:

```json
{
  "project_name": {
    "anyOf": [{"type": "string"}, {"type": "null"}],
    "default": null
  }
}
```

Now `null` is a valid value for the type, and clients that auto-fill defaults won't cause validation errors.

## Affected tools

`list_projects`, `fetch_runs`, `list_datasets`, `list_examples`, `read_dataset`, `read_example`, `list_experiments`, `get_prompt_tool`, and their registration wrappers.

## Testing

Verified locally: `list-projects --limit 2` now works without any post-generation patches on the generated CLI.