### PR TITLE
fix(usage): pass tenant header for billing usage

### DIFF
--- a/langsmith_mcp_server/common/helpers.py
+++ b/langsmith_mcp_server/common/helpers.py
@@ -170,6 +170,26 @@ async def get_api_key_and_endpoint_from_context(ctx: Context) -> tuple[str, str]
     return (str(api_key), str(endpoint).rstrip("/"))
 
 
+async def get_api_key_endpoint_workspace_from_context(
+    ctx: Context,
+) -> tuple[str, str, str | None]:
+    """
+    Get API key, endpoint, and workspace ID from FastMCP context.
+
+    Used by tools that call LangSmith REST APIs directly and need to forward
+    workspace context via headers.
+    """
+    await get_client_from_context(ctx)  # populates ctx state
+    api_key = await ctx.get_state("api_key")
+    endpoint = (await ctx.get_state("endpoint")) or "https://api.smith.langchain.com"
+    workspace_id = (await ctx.get_state("workspace_id")) or None
+    return (
+        str(api_key),
+        str(endpoint).rstrip("/"),
+        str(workspace_id) if workspace_id else None,
+    )
+
+
 def get_langgraph_app_host_name(run_stats: dict) -> Optional[str]:
     """
     Get the langgraph app host name from the run stats

--- a/langsmith_mcp_server/services/register_tools.py
+++ b/langsmith_mcp_server/services/register_tools.py
@@ -8,6 +8,7 @@ from fastmcp.server import Context
 
 from langsmith_mcp_server.common.helpers import (
     get_api_key_and_endpoint_from_context,
+    get_api_key_endpoint_workspace_from_context,
     get_client_from_context,
 )
 from langsmith_mcp_server.monitoring import (
@@ -774,7 +775,9 @@ client = Client()  # Will automatically use environment variables
             List of billing metric objects with augmented groups, or dict with "error" key
         """
         try:
-            api_key, endpoint = await get_api_key_and_endpoint_from_context(ctx)
+            api_key, endpoint, workspace_id = await get_api_key_endpoint_workspace_from_context(
+                ctx
+            )
             on_current = on_current_plan.lower() == "true"
             session_id = get_monitoring_session_id()
             inputs = {
@@ -792,6 +795,7 @@ client = Client()  # Will automatically use environment variables
                     ending_before=ending_before,
                     on_current_plan=on_current,
                     workspace=workspace,
+                    workspace_id=workspace_id,
                 )
                 if isinstance(result, dict) and "error" in result:
                     return result

--- a/langsmith_mcp_server/services/tools/usage.py
+++ b/langsmith_mcp_server/services/tools/usage.py
@@ -14,6 +14,7 @@ def _request(
     endpoint: str,
     path: str,
     params: dict[str, str] | None = None,
+    workspace_id: str | None = None,
 ) -> dict[str, Any] | list[Any]:
     """GET request to LangSmith API. Returns JSON (dict or list)."""
     base = (endpoint or _DEFAULT_ENDPOINT).rstrip("/")
@@ -23,6 +24,8 @@ def _request(
     req = urllib.request.Request(url, method="GET")
     req.add_header("Accept", "application/json")
     req.add_header("X-API-Key", api_key)
+    if workspace_id:
+        req.add_header("X-Tenant-Id", workspace_id)
     try:
         with urllib.request.urlopen(req, timeout=30) as resp:
             return json.loads(resp.read().decode())
@@ -33,14 +36,18 @@ def _request(
         return {"error": str(e)}
 
 
-def _list_workspaces(api_key: str, endpoint: str) -> dict[str, Any] | list[Any]:
+def _list_workspaces(
+    api_key: str, endpoint: str, workspace_id: str | None = None
+) -> dict[str, Any] | list[Any]:
     """GET /api/v1/workspaces."""
-    return _request(api_key, endpoint, "/api/v1/workspaces")
+    return _request(api_key, endpoint, "/api/v1/workspaces", workspace_id=workspace_id)
 
 
-def _get_workspace_by_id(api_key: str, endpoint: str, workspace_id: str) -> dict[str, Any]:
+def _get_workspace_by_id(
+    api_key: str, endpoint: str, workspace_id: str, tenant_id: str | None = None
+) -> dict[str, Any]:
     """GET /api/v1/workspaces/{id}."""
-    out = _request(api_key, endpoint, f"/api/v1/workspaces/{workspace_id}")
+    out = _request(api_key, endpoint, f"/api/v1/workspaces/{workspace_id}", workspace_id=tenant_id)
     return out if isinstance(out, dict) else {"error": "Unexpected response"}
 
 
@@ -48,18 +55,19 @@ def _build_workspace_id_to_name(
     api_key: str,
     endpoint: str,
     single_workspace: str | None,
+    tenant_id: str | None = None,
 ) -> dict[str, str]:
     """Build workspace_id -> name. If single_workspace set, fetch only that one."""
     id_to_name: dict[str, str] = {}
     if single_workspace:
         single_workspace = single_workspace.strip()
         if len(single_workspace) == 36 and single_workspace.count("-") == 4:
-            resp = _get_workspace_by_id(api_key, endpoint, single_workspace)
+            resp = _get_workspace_by_id(api_key, endpoint, single_workspace, tenant_id=tenant_id)
             if isinstance(resp, dict) and "error" not in resp and resp.get("id"):
                 name = resp.get("display_name") or resp.get("name") or single_workspace
                 id_to_name[str(resp["id"])] = name
                 return id_to_name
-        ws_resp = _list_workspaces(api_key, endpoint)
+        ws_resp = _list_workspaces(api_key, endpoint, workspace_id=tenant_id)
         workspaces: list[dict] = []
         if isinstance(ws_resp, list):
             workspaces = [w for w in ws_resp if isinstance(w, dict)]
@@ -75,7 +83,7 @@ def _build_workspace_id_to_name(
                 id_to_name[wid] = name
                 return id_to_name
         return id_to_name
-    ws_resp = _list_workspaces(api_key, endpoint)
+    ws_resp = _list_workspaces(api_key, endpoint, workspace_id=tenant_id)
     if isinstance(ws_resp, list):
         for w in ws_resp:
             if isinstance(w, dict) and w.get("id"):
@@ -121,6 +129,7 @@ def get_billing_usage_tool(
     ending_before: str,
     on_current_plan: bool = True,
     workspace: str | None = None,
+    workspace_id: str | None = None,
 ) -> dict[str, Any] | list[dict]:
     """
     Fetch org billing usage (trace counts) with workspace names inline.
@@ -137,6 +146,8 @@ def get_billing_usage_tool(
         ending_before: End of range (ISO 8601).
         on_current_plan: If true, only usage on current plan.
         workspace: Optional single workspace UUID or name to filter to.
+        workspace_id: Optional workspace ID used as the X-Tenant-Id header for
+            org-scoped API keys.
 
     Returns:
         List of billing metrics with groups as
@@ -148,12 +159,20 @@ def get_billing_usage_tool(
         "ending_before": ending_before,
         "on_current_plan": "true" if on_current_plan else "false",
     }
-    raw = _request(api_key, endpoint, "/api/v1/orgs/current/billing/usage", params)
+    raw = _request(
+        api_key,
+        endpoint,
+        "/api/v1/orgs/current/billing/usage",
+        params,
+        workspace_id=workspace_id,
+    )
     if isinstance(raw, dict) and "error" in raw:
         return raw
     if not isinstance(raw, list) or not raw:
         return {"error": "Unexpected billing usage response"}
-    workspace_id_to_name = _build_workspace_id_to_name(api_key, endpoint, workspace)
+    workspace_id_to_name = _build_workspace_id_to_name(
+        api_key, endpoint, workspace, tenant_id=workspace_id
+    )
     only_workspace_id: str | None = None
     if workspace and workspace_id_to_name:
         only_workspace_id = next(iter(workspace_id_to_name.keys()), None)

--- a/tests/tools/test_usage_tool.py
+++ b/tests/tools/test_usage_tool.py
@@ -1,0 +1,83 @@
+"""Tests for usage tools."""
+
+import json
+from unittest.mock import patch
+
+from langsmith_mcp_server.services.tools.usage import (
+    _request,
+    get_billing_usage_tool,
+)
+
+
+class FakeResponse:
+    """Minimal context-manager response for urllib.request.urlopen."""
+
+    def __init__(self, payload):
+        self.payload = json.dumps(payload).encode()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return False
+
+    def read(self):
+        return self.payload
+
+
+def _headers(request):
+    return {key.lower(): value for key, value in request.header_items()}
+
+
+def test_request_adds_tenant_header_when_workspace_id_is_provided():
+    """Org-scoped LangSmith endpoints require X-Tenant-Id for workspace-scoped keys."""
+    requests = []
+
+    def fake_urlopen(request, timeout):
+        requests.append(request)
+        return FakeResponse({"ok": True})
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        result = _request(
+            "test-key",
+            "https://api.smith.langchain.com",
+            "/api/v1/orgs/current/billing/usage",
+            workspace_id="workspace-123",
+        )
+
+    assert result == {"ok": True}
+    assert _headers(requests[0])["x-tenant-id"] == "workspace-123"
+
+
+def test_billing_usage_propagates_workspace_id_to_rest_requests():
+    """The billing tool should preserve LANGSMITH_WORKSPACE_ID for raw REST calls."""
+    requests = []
+
+    def fake_urlopen(request, timeout):
+        requests.append(request)
+        if request.full_url.startswith(
+            "https://api.smith.langchain.com/api/v1/orgs/current/billing/usage"
+        ):
+            return FakeResponse([{"name": "trace_count", "groups": {"workspace-123": 5}}])
+        if request.full_url == "https://api.smith.langchain.com/api/v1/workspaces":
+            return FakeResponse([{"id": "workspace-123", "display_name": "Production"}])
+        return FakeResponse({"error": "unexpected url"})
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        result = get_billing_usage_tool(
+            api_key="test-key",
+            endpoint="https://api.smith.langchain.com",
+            starting_on="2026-03-01T00:00:00Z",
+            ending_before="2026-03-12T00:00:00Z",
+            workspace_id="workspace-123",
+        )
+
+    assert result == [
+        {
+            "name": "trace_count",
+            "groups": {
+                "workspace-123": {"workspace_name": "Production", "value": 5},
+            },
+        }
+    ]
+    assert all(_headers(request)["x-tenant-id"] == "workspace-123" for request in requests)


### PR DESCRIPTION
Fixes #54

Forward the workspace ID from the MCP context to the raw LangSmith billing usage REST calls as `X-Tenant-Id`. This fixes 403s for org-scoped API keys while preserving the existing workspace-name augmentation behavior.

## Tests

- `uv run --group test pytest tests/tools/test_usage_tool.py -q`
- `uv run --group test pytest --disable-socket --allow-unix-socket tests/ --timeout 10`
