### PR TITLE
docs: fix broken hosted URL in Quickstart, recommend uvx stdio install

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,30 +21,35 @@ The server enables powerful capabilities including:
 
 ## 🚀 Quickstart
 
-A **hosted version** of the LangSmith MCP Server is available over HTTP-streamable transport, so you can connect without running the server yourself:
+The fastest way to get going is to run the server locally over stdio with [`uvx`](https://github.com/astral-sh/uv) — no clone, no virtualenv, no Docker. `uvx` fetches the published [`langsmith-mcp-server`](https://pypi.org/project/langsmith-mcp-server/) package and launches it on demand.
 
-- **URL:** `https://langsmith-mcp-server.onrender.com/mcp`
-- **Hosting:** [Render](https://render.com), built from this public repo using the project's Dockerfile.
+**Prerequisite:** install `uv` ([instructions](https://github.com/astral-sh/uv#installation)):
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
 
-Use it like any HTTP-streamable MCP server: point your client at the URL and send your LangSmith API key in the `LANGSMITH-API-KEY` header. No local install or Docker required.
-
-**Example (Cursor `mcp.json`):**
+**Example MCP client config (Cursor / Claude Desktop / Claude Code `mcp.json`):**
 ```json
 {
   "mcpServers": {
-    "LangSmith MCP (Hosted)": {
-      "url": "https://langsmith-mcp-server.onrender.com/mcp",
-      "headers": {
-        "LANGSMITH-API-KEY": "lsv2_pt_your_api_key_here"
+    "langsmith": {
+      "command": "uvx",
+      "args": ["langsmith-mcp-server"],
+      "env": {
+        "LANGSMITH_API_KEY": "lsv2_pt_your_api_key_here",
+        "LANGSMITH_WORKSPACE_ID": "optional-workspace-uuid",
+        "LANGSMITH_ENDPOINT": "https://api.smith.langchain.com"
       }
     }
   }
 }
 ```
 
-Optional headers: `LANGSMITH-WORKSPACE-ID`, `LANGSMITH-ENDPOINT` (same as in the [Docker Deployment](#-docker-deployment-http-streamable) section below).
+- `LANGSMITH_API_KEY` is required.
+- `LANGSMITH_WORKSPACE_ID` is optional (use it when your API key is scoped to multiple workspaces).
+- `LANGSMITH_ENDPOINT` is optional — set it to your **self-hosted** LangSmith URL if you're not on [LangSmith Cloud](https://smith.langchain.com).
 
-> **Note:** This deployed instance is intended for [LangSmith Cloud](https://smith.langchain.com). If you use a **self-hosted** LangSmith instance, run the server yourself and point it at your endpoint—see the [Docker Deployment](#-docker-deployment-http-streamable) section below.
+> **Note:** A previous version of this README advertised a hosted HTTP-streamable endpoint at `https://langsmith-mcp-server.onrender.com/mcp`. That deployment is currently unavailable (responds with `HTTP 404`), so the stdio install above is the recommended path. If you specifically need HTTP-streamable transport, deploy it yourself — see the [Docker Deployment](#-docker-deployment-http-streamable) section below.
 
 ## 🛠️ Available Tools
 


### PR DESCRIPTION
## Summary

- The README's **Quickstart** section currently advertises a hosted HTTP-streamable endpoint at `https://langsmith-mcp-server.onrender.com/mcp`. That deployment is **deprecated/down** — a `POST /mcp` returns `HTTP 404 Not Found`, so the copy-paste config in the README does not work for new users (also confirmed in #96, where the reporter says it "used to work but is now deprecated").
- Replace the Quickstart with the published-PyPI + `uvx langsmith-mcp-server` **stdio** recipe, which is the supported install path and matches the `From PyPI` section further down in the README.
- Preserve the LangSmith Cloud / self-hosted guidance and the link to the existing `Docker Deployment` section for users who specifically need HTTP-streamable transport.

## Related

- Related to #96 — that issue tracks a separate Cursor OAuth bug against the new official hosted endpoint at `https://api.smith.langchain.com/mcp` (`redirect_uri must be http loopback or https to a domain host`). This PR does not fix that OAuth issue, but it does remove the *other* broken hosted reference from the README and gives users a working stdio path they can use in the meantime.

## Repro of the broken endpoint

```bash
$ curl -sS -o /dev/null -w "HTTP %{http_code}\n" -m 15 \
    https://langsmith-mcp-server.onrender.com/mcp \
    -H "LANGSMITH-API-KEY: lsv2_pt_..." \
    -H "Accept: application/json, text/event-stream" \
    -H "Content-Type: application/json" \
    -X POST \
    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"probe","version":"0"}}}'
HTTP 404
```

If the Render deployment is intentionally retired, this PR is the correct doc fix. If maintainers want to additionally point users to the new `https://api.smith.langchain.com/mcp` hosted endpoint, that can go on top of this commit once the OAuth issue in #96 is resolved.

## Test plan

- [x] `curl` confirms the hosted `/mcp` endpoint returns `404`
- [x] The new config matches the `From PyPI` example already in the README (`uvx langsmith-mcp-server` + `LANGSMITH_API_KEY` / `LANGSMITH_WORKSPACE_ID` / `LANGSMITH_ENDPOINT`)
- [x] Internal anchor `#-docker-deployment-http-streamable` still resolves (unchanged)
- [ ] Maintainer to verify rendered Markdown on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)