### PR TITLE
[codex] Move GitHub Actions to RunsOn v3

### DIFF
--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -26,7 +26,7 @@ env:
 jobs:
   build:
     name: "make lint #${{ inputs.python-version }}"
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=ci-light
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -24,7 +24,7 @@ jobs:
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=ci-light
     timeout-minutes: 20
     name: "make test #${{ inputs.python-version }}"
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
   build:
     if: github.ref == 'refs/heads/main' || inputs.dangerous-nonmain-release
     environment: Scheduled testing
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=ci-light
 
     outputs:
       pkg-name: ${{ steps.check-version.outputs.pkg-name }}
@@ -80,7 +80,7 @@ jobs:
   publish:
     needs:
       - build
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=ci-light
     permissions:
       # This permission is used for trusted publishing:
       # https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/
@@ -119,7 +119,7 @@ jobs:
     needs:
       - build
       - publish
-    runs-on: ubuntu-latest
+    runs-on: runs-on=${{ github.run_id }}/runner=ci-light
     permissions:
       # This permission is needed by `ncipollo/release-action` to
       # create the GitHub release.


### PR DESCRIPTION
## Summary
- Replace GitHub-hosted workflow runners with RunsOn v3 labels.
- Use `ci-light` for lint, test, release build, publish, and release-tag jobs.

## Validation
- `ruby -ryaml -e 'ARGV.each { |path| YAML.load_file(path) }' $(rg --files .github/workflows)`
- `git diff --check`
- `rg -n "runs-on:\\s*.*(ubuntu-latest|ubuntu-22\\.04|macos-|windows-)" .github/workflows` returned no matches
- `actionlint` reports a pre-existing `.github/workflows/release.yml:152` reference to `needs.release-notes`, unchanged by this PR